### PR TITLE
`UND_ERR_SOCKET` is currently `BAD_BODY` and that has decoding errors

### DIFF
--- a/runner/http/fetch.ts
+++ b/runner/http/fetch.ts
@@ -66,10 +66,42 @@ function toHttpError(err: any): HttpError {
       return "NETWORK_ERROR";
     case "EAGAIN":
       return "NETWORK_ERROR";
-    case "UND_ERR_SOCKET":
-      return "NETWORK_ERROR";
     case "ERR_INVALID_URL":
       return "BAD_URL";
+    case "UND_ERR":
+      return "NETWORK_ERROR"
+    case "UND_ERR_CONNECT_TIMEOUT":
+      return "NETWORK_ERROR"
+    case "UND_ERR_HEADERS_TIMEOUT":
+      return "NETWORK_ERROR"
+    case "UND_ERR_HEADERS_OVERFLOW":
+      return "NETWORK_ERROR"
+    case "UND_ERR_BODY_TIMEOUT":
+      return "NETWORK_ERROR"
+    case "UND_ERR_RESPONSE_STATUS_CODE":
+      return "NETWORK_ERROR"
+    case "UND_ERR_INVALID_ARG":
+      return "NETWORK_ERROR"
+    case "UND_ERR_INVALID_RETURN_VALUE":
+      return "NETWORK_ERROR"
+    case "UND_ERR_ABORTED":
+      return "NETWORK_ERROR"
+    case "UND_ERR_DESTROYED":
+      return "NETWORK_ERROR"
+    case "UND_ERR_CLOSED":
+      return "NETWORK_ERROR"
+    case "UND_ERR_SOCKET":
+      return "NETWORK_ERROR"
+    case "UND_ERR_NOT_SUPPORTED":
+      return "NETWORK_ERROR"
+    case "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH":
+      return "NETWORK_ERROR"
+    case "UND_ERR_RES_CONTENT_LENGTH_MISMATCH":
+      return "NETWORK_ERROR"
+    case "UND_ERR_INFO":
+      return "NETWORK_ERROR"
+    case "UND_ERR_RES_EXCEEDED_MAX_SIZE":
+      return "NETWORK_ERROR"
   }
 
   switch (err.name) {

--- a/runner/http/fetch.ts
+++ b/runner/http/fetch.ts
@@ -66,6 +66,8 @@ function toHttpError(err: any): HttpError {
       return "NETWORK_ERROR";
     case "EAGAIN":
       return "NETWORK_ERROR";
+    case "UND_ERR_SOCKET":
+      return "NETWORK_ERROR";
     case "ERR_INVALID_URL":
       return "BAD_URL";
   }

--- a/runner/http/fetch.ts
+++ b/runner/http/fetch.ts
@@ -107,8 +107,6 @@ function toHttpError(err: any): HttpError {
   switch (err.name) {
     case "AbortError":
       return "TIMEOUT";
-    case "TypeError":
-      return "BAD_BODY";
   }
 
   return err.cause?.code;


### PR DESCRIPTION
I got a `code: 'UND_ERR_SOCKET'` when the target server crashed

```
code: 'UND_ERR_SOCKET',
cause: SocketError: other side closed
    at Socket.onSocketEnd (node:internal/deps/undici/undici:9227:26)
    at Socket.emit (node:events:525:35)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'UND_ERR_SOCKET',
```

and that was returned as `BAD_BODY` by `builtin:http`

and went into the `_ ->` catch all match for

https://github.com/andrewMacmurray/elm-concurrent-task/blob/d488f443841fc20b8c7c46e588a78b25f6a48e3c/src/ConcurrentTask/Http.elm#L290-L307

```
UnexpectedError (ErrorsDecoderFailure { error = Field "value" (Field "error" (Failure "Unknown error code: BAD_BODY" <internals>)), function = "builtin:http" })
```

Though this PR adds `UND_ERR_SOCKET`, ~but I don't know if there are more~. It's https://github.com/nodejs/undici/blob/932e5f681fd59af7da9fd3090cbef10ef8a0da97/docs/api/Errors.md?plain=1#L10-L28

I can also see adding a `BAD_BODY` scenario

```diff
                     "BAD_URL" ->
                         Decode.succeed (BadUrl r.url)
 
+                    "BAD_BODY" ->
+                        Decode.succeed (BadBody ??? )
+
                     _ ->
                         Decode.fail ("Unknown error code: " ++ code)
```

but I don't think we have enough information to construct `BadBody`

So I think we should remove that `return` from fetch.ts

```diff
   switch (err.name) {
     case "AbortError":
       return "TIMEOUT";
-    case "TypeError":
-      return "BAD_BODY";
   }
 
```

