### PR TITLE
Add `ConcurrentTask.debug` with builtin task

### DIFF
--- a/runner/index.ts
+++ b/runner/index.ts
@@ -49,6 +49,7 @@ export interface Error {
 // Built In Tasks
 
 export interface Builtins {
+  debugLog?: (message: string) => void;
   http?: (request: HttpRequest) => Promise<HttpResponse>;
   timeNow?: () => number;
   timeZoneOffset?: () => number;
@@ -65,6 +66,7 @@ export interface Builtins {
 }
 
 const BuiltInTasks: Builtins = {
+  debugLog: console.log,
   http: fetchAdapter.http,
   timeNow: () => Date.now(),
   timeZoneOffset: () => getTimezoneOffset(),


### PR DESCRIPTION
This adds a `debug` utility where you can quickly peek at the value of a task in a chain and print it to the console:

e.g:
```elm
import ConcurrentTask exposing (ConcurrentTask)


-- Prints to the console "Debug - Success: 130"
myTask : ConcurrentTask x Int
myTask =
    ConcurrentTask.succeed 123
        |> ConcurrentTask.map (\n -> n + 7)
        |> ConcurrentTask.debug Debug.toString Debug.toString

-- Prints to the console "Debug - Failure: 'error'"
myErrorTask : ConcurrentTask String Int
myErrorTask =
    ConcurrentTask.succeed 123
        |> ConcurrentTask.map (\n -> n + 7)
        |> ConcurrentTask.andThenDo (ConcurrentTask.fail "error")
        |> ConcurrentTask.debug Debug.toString Debug.toString
```

By passing `Debug.toString` it prevents debug code from being shipped to production (inspired by `elm-ui`'s [Element.explain](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/Element#explain)) -