### PR TITLE
Identify pool on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ npm install @andrewmacmurray/elm-concurrent-task
 
 ### 2. Add to your Elm app
 
-Your Elm program needs
+Your Elm program needs:
 
-- A `ConcurrentTask.Pool` in your `Model` to keep track of each task attempt:
+- A single `ConcurrentTask.Pool` in your `Model` to keep track of each task attempt:
 
   ```elm
   type alias Model =
@@ -364,6 +364,14 @@ const tasks = {
 ```
 
 **NOTE**: for a more complete `localStorage` integration with proper error handling [check out the localstorage example](https://github.com/andrewMacmurray/elm-concurrent-task/blob/ba7c8af4b1afeff138ba839511d4411a0a40bbb1/examples/localstorage-fruit-trees/src/index.ts).
+
+## Re-using ports
+
+Each `send` and `receive` port pair only support **one** `ConcurrentTask.Pool` subscribed at a time.
+**Weird** things can happen if you have **two or more** `ConcurrentTask.Pool`s using the same ports at the same time.
+
+Generally this should not be needed, but if you have a use-case, please leave an [issue](https://github.com/andrewMacmurray/elm-concurrent-task/issues).
+
 
 ## Develop Locally
 


### PR DESCRIPTION
Resolves #19

When a task `Pool` is initialised it now asks the runner for a unique id before any tasks are executed (the runner keeps track of the number of pools that have been initialised).

This prevents some weird behaviour seen in a typical single page app setup where switching back and forth between pages with long running tasks (e.g. [Page1](https://github.com/andrewMacmurray/elm-concurrent-task/blob/main/examples/spa-example/src/Pages/Home_.elm#L44-L58) and [Page2](https://github.com/andrewMacmurray/elm-concurrent-task/blob/main/examples/spa-example/src/Pages/Posts.elm#L44-L58) would mean a page might receive task results from a previous page init.