### PR TITLE
getZoneName calls correct builtin function, adds links to kernel code

### DIFF
--- a/integration/src/Main.elm
+++ b/integration/src/Main.elm
@@ -4,12 +4,14 @@ import ConcurrentTask as Task exposing (ConcurrentTask, UnexpectedError(..))
 import ConcurrentTask.Http as Http
 import ConcurrentTask.Process
 import ConcurrentTask.Random
+import ConcurrentTask.Time
 import Integration.Runner as Runner exposing (RunnerProgram)
 import Integration.Spec as Spec exposing (Spec)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
 import Random
 import Set
+import Time
 
 
 
@@ -43,6 +45,8 @@ specs =
     , httpBadBodySpec
     , httpBadStatusSpec
     , randomSpec
+    , timeZoneSpec
+    , timeHereSpec
     ]
 
 
@@ -333,6 +337,33 @@ randomSpec =
 allElementsUnique : List comparable -> Bool
 allElementsUnique xs =
     List.length xs == Set.size (Set.fromList xs)
+
+
+timeZoneSpec : Spec
+timeZoneSpec =
+    Spec.describe
+        "Time.getZoneName"
+        "smoke test for Time.getZoneName"
+        ConcurrentTask.Time.getZoneName
+        (Spec.assertSuccess
+            (\zone ->
+                case zone of
+                    Time.Offset _ ->
+                        Spec.failWith "Expected actual timezone but got an offset" zone
+
+                    Time.Name _ ->
+                        Spec.pass
+            )
+        )
+
+
+timeHereSpec : Spec
+timeHereSpec =
+    Spec.describe
+        "Time.here"
+        "smoke test for Time.here"
+        ConcurrentTask.Time.here
+        (Spec.assertSuccess (\_ -> Spec.pass))
 
 
 

--- a/runner/browser/dom.ts
+++ b/runner/browser/dom.ts
@@ -6,14 +6,19 @@ import {
   SetViewportOfOptions,
 } from "browser";
 
+// Relevant Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L322-L328
+// Note: `focus` is called using `Elm.Kernel.Browser.call "focus"`
 export function focus(id: string): void | DomError {
   return withDomNode(id, (el) => el.focus());
 }
 
+// Relevant Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L322-L328
+// Note: `blur` is called using `Elm.Kernel.Browser.call "blur"`
 export function blur(id: string): void | DomError {
   return withDomNode(id, (el) => el.blur());
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L335-L346
 export function getViewport(): Viewport {
   return {
     scene: getBrowserScene(),
@@ -26,6 +31,7 @@ export function getViewport(): Viewport {
   };
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L372-L389
 export function getViewportOf(id: string): Viewport | DomError {
   return withDomNode(id, (el) => ({
     scene: {
@@ -41,10 +47,12 @@ export function getViewportOf(id: string): Viewport | DomError {
   }));
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L358-L365
 export function setViewport(options: SetViewportOptions): void {
   window.scroll(options.y, options.y);
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L392-L400
 export function setViewportOf(options: SetViewportOfOptions): void | DomError {
   return withDomNode(options.id, (el) => {
     el.scrollLeft = options.x;
@@ -52,6 +60,7 @@ export function setViewportOf(options: SetViewportOfOptions): void | DomError {
   });
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L407-L430
 export function getElement(id: string): DomElement | DomError {
   return withDomNode(id, (el) => {
     const rect = el.getBoundingClientRect();
@@ -77,6 +86,7 @@ export function getElement(id: string): DomElement | DomError {
 
 // Helpers
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L293-L305
 function withDomNode<a>(
   id: string,
   callback: (el: HTMLElement) => a
@@ -88,6 +98,7 @@ function withDomNode<a>(
   return { error: null };
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/browser/blob/master/src/Elm/Kernel/Browser.js#L348-L356
 function getBrowserScene(): { width: number; height: number } {
   const body = document.body;
   const elem = document.documentElement;

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -88,14 +88,18 @@ const BuiltInTasks: Builtins = {
   domGetElement: dom.getElement,
 };
 
+// Equivalent Elm Kernel code: https://github.com/elm/core/blob/master/src/Elm/Kernel/Process.js#L9-L18
+// Note: this implementation uses a promise rather than the scheduler callback
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/time/blob/1.0.0/src/Elm/Kernel/Time.js#L27-L35
 function getTimezoneOffset(): number {
   return -new Date().getTimezoneOffset();
 }
 
+// Equivalent Elm Kernel code: https://github.com/elm/time/blob/1.0.0/src/Elm/Kernel/Time.js#L38-L52
 function getTimeZoneName(): string | number {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/src/ConcurrentTask/Time.elm
+++ b/src/ConcurrentTask/Time.elm
@@ -83,7 +83,7 @@ A direct replacement for `elm/time`'s [`Time.getZoneName`](https://package.elm-l
 getZoneName : ConcurrentTask x Time.ZoneName
 getZoneName =
     ConcurrentTask.define
-        { function = "builtin:timeZoneOffset"
+        { function = "builtin:timeZoneName"
         , expect = ConcurrentTask.expectJson decodeZoneName
         , errors = ConcurrentTask.expectNoErrors
         , args = Encode.null


### PR DESCRIPTION
Closes #23 

Thanks to [@lue-bird](https://github.com/lue-bird) for spotting this.

This PR
- Makes `Time.getZoneName` call the correct builtin function and adds some integration smoke tests
- adds some links to the relevant / equivalent Elm Kernel code.