### PR TITLE
Adds hybrid JS exports for commonjs and mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,16 @@
   "name": "@andrewmacmurray/elm-concurrent-task",
   "version": "1.0.0",
   "description": "Run a tree of Tasks concurrently, call JS functions as Tasks (Task Ports)",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/mjs/index.js",
+  "types": "lib/mjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/mjs/index.d.ts"
+    }
+  },
   "files": [
     "lib"
   ],
@@ -14,7 +22,7 @@
     "review": "elm-review --fix",
     "review:ci": "elm-review",
     "review:watch": "elm-review --watch",
-    "runner:compile": "tsc",
+    "runner:compile": "rm -rf lib/* && tsc -p tsconfig-mjs.json && tsc -p tsconfig-cjs.json && ./scripts/package-fixup.sh",
     "check-versions": "node ./scripts/versions.js"
   },
   "author": "Andrew MacMurray",

--- a/runner/http/fetch.ts
+++ b/runner/http/fetch.ts
@@ -15,7 +15,11 @@ export function http(request: HttpRequest): Promise<HttpResponse> {
     signal: controller?.signal,
   })
     .then((res: Response) => {
-      const headers = Object.fromEntries(res.headers.entries());
+      const headers: { [key: string]: string } = {};
+      res.headers.forEach((val, key) => {
+        headers[key] = val;
+      });
+
       switch (request.expect) {
         case "STRING": {
           return res.text().then((x) => ({

--- a/scripts/package-fixup.sh
+++ b/scripts/package-fixup.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Adds package.json files to cjs/mjs subtrees
+
+cat >lib/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >lib/mjs/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,33 +1,21 @@
 {
   "compilerOptions": {
-    "outDir": "lib",
     "removeComments": true,
-    "target": "ESNext",
     "declaration": true,
-
-    // Module resolution
     "baseUrl": "runner",
     "esModuleInterop": true,
     "moduleResolution": "node",
-
-    // Source Map
     "sourceMap": true,
     "sourceRoot": "./runner",
-
-    // Strict Checks
     "alwaysStrict": true,
     "allowUnreachableCode": false,
     "noImplicitAny": true,
     "strictNullChecks": true,
-
-    // Linter Checks
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
   "include": ["runner/**/*.ts"],
-  "exclude": [
-    "node_modules/**/*"
-  ]
+  "exclude": ["node_modules/**/*"]
 }

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "lib/cjs",
+    "target": "ES2015"
+  }
+}

--- a/tsconfig-mjs.json
+++ b/tsconfig-mjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "lib/mjs",
+    "target": "ESNext"
+  }
+}


### PR DESCRIPTION
This allows projects to use either `require` or `import` syntax when using the `@andrewmacmurray/elm-concurrent-task` `npm` package.

This makes it easier to use concurrent task without using a bundler in nodejs.

Based on the technique from this great blog post https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html