### PR TITLE
Fix race condition on first task attempt in update

### DIFF
--- a/examples/dom-operations/package-lock.json
+++ b/examples/dom-operations/package-lock.json
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/examples/localstorage-fruit-trees/package-lock.json
+++ b/examples/localstorage-fruit-trees/package-lock.json
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@andrewmacmurray/elm-concurrent-task",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@andrewmacmurray/elm-concurrent-task",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "elm": "^0.19.1-6",

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -138,9 +138,11 @@ export function register(options: Options): void {
     if ("command" in payload) {
       switch (payload.command) {
         case "identify-pool": {
-          send({ poolId });
-          nextPoolId();
-          return;
+          // The Promise.resolve wrapper here prevents a race condition in Elm where sometimes the Model is not updated in time before the poolId is received
+          return Promise.resolve().then(() => {
+            send({ poolId });
+            nextPoolId();
+          });
         }
         default: {
           throw new Error(`Unrecognised internal command: ${payload}`);


### PR DESCRIPTION
In some cases where a task was first started in `update`, the sub-tasks would not be run. This was because the Elm model was not updated in time before the first `poolId` was received.

Adding a `Promise.resolve` wrapper around the `send({ poolId })` gives elm enough time to tick the model forward.