### PR TITLE
Fix debug ignoring log tasks

### DIFF
--- a/examples/many-requests/src/Main.elm
+++ b/examples/many-requests/src/Main.elm
@@ -113,6 +113,7 @@ longRequest ms =
         , expect = Http.expectJson (Decode.field "message" Decode.string)
         , timeout = Nothing
         }
+        |> Task.debug Debug.toString Debug.toString
 
 
 sometimesFails : ConcurrentTask Http.Error String
@@ -123,6 +124,7 @@ sometimesFails =
         , expect = Http.expectJson (Decode.field "message" Decode.string)
         , timeout = Nothing
         }
+        |> Task.debug Debug.toString Debug.toString
 
 
 httpError : ConcurrentTask Http.Error String
@@ -133,6 +135,7 @@ httpError =
         , expect = Http.expectJson (Decode.field "message" Decode.string)
         , timeout = Nothing
         }
+        |> Task.debug Debug.toString Debug.toString
 
 
 {-| Simple retry mechanism with backoff

--- a/src/ConcurrentTask.elm
+++ b/src/ConcurrentTask.elm
@@ -688,13 +688,13 @@ debug toOk toErr task =
             (\a ->
                 toOk a
                     |> debugLog "Success"
-                    |> (\_ -> succeed a)
+                    |> return a
             )
         |> onError
             (\x ->
                 toErr x
                     |> debugLog "Failure"
-                    |> (\_ -> fail x)
+                    |> andThenDo (fail x)
             )
 
 


### PR DESCRIPTION
Closes #30

`ConcurrentTask.debug` was ignoring the log tasks (how rude of it!) on failure and success. This change ensures they get called.

It's a bit tricky to unit / integration test this, but I've included it in the `many-requests` example so the additional debug logs can be seen:

<img width="1432" alt="Screenshot 2024-03-15 at 08 15 28" src="https://github.com/andrewMacmurray/elm-concurrent-task/assets/14013616/c9f29548-7aeb-4982-b045-49de98f394cb">
