### PR TITLE
Simplify the Pool type

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Your Elm program needs:
 
   ```elm
   type alias Model =
-      { tasks : ConcurrentTask.Pool Msg Error Success
+      { tasks : ConcurrentTask.Pool Msg
       }
   ```
 
@@ -214,7 +214,7 @@ Your Elm program needs:
 
   ```elm
   type Msg
-      = OnProgress ( ConcurrentTask.Pool Msg Error Success, Cmd Msg ) -- updates task progress
+      = OnProgress ( ConcurrentTask.Pool Msg, Cmd Msg ) -- updates task progress
       | OnComplete (ConcurrentTask.Response Error Success) -- called when a task completes
   ```
 
@@ -236,12 +236,12 @@ import Json.Decode as Decode
 
 
 type alias Model =
-    { tasks : ConcurrentTask.Pool Msg Error Titles
+    { tasks : ConcurrentTask.Pool Msg
     }
 
 
 type Msg
-    = OnProgress ( ConcurrentTask.Pool Msg Error Titles, Cmd Msg )
+    = OnProgress ( ConcurrentTask.Pool Msg, Cmd Msg )
     | OnComplete (ConcurrentTask.Response Error Titles)
 
 

--- a/examples/dom-operations/src/Main.elm
+++ b/examples/dom-operations/src/Main.elm
@@ -57,7 +57,7 @@ type alias Flags =
 
 
 type alias Pool =
-    ConcurrentTask.Pool Msg Error Output
+    ConcurrentTask.Pool Msg
 
 
 type alias Error =

--- a/examples/fruits-pipeline-worker/src/Main.elm
+++ b/examples/fruits-pipeline-worker/src/Main.elm
@@ -51,7 +51,7 @@ type Msg
 
 
 type alias Pool =
-    Task.Pool Msg Error Output
+    Task.Pool Msg
 
 
 type Error

--- a/examples/localstorage-fruit-trees/src/Main.elm
+++ b/examples/localstorage-fruit-trees/src/Main.elm
@@ -75,7 +75,7 @@ updatePears n fruits =
 
 
 type alias Pool =
-    ConcurrentTask.Pool Msg Error Output
+    ConcurrentTask.Pool Msg
 
 
 type alias Error =

--- a/examples/many-requests/src/Main.elm
+++ b/examples/many-requests/src/Main.elm
@@ -3,7 +3,7 @@ port module Main exposing (main)
 import ConcurrentTask as Task exposing (ConcurrentTask)
 import ConcurrentTask.Http as Http
 import ConcurrentTask.Process
-import Json.Decode as Decode exposing (Decoder)
+import Json.Decode as Decode
 
 
 {-| Many Requests
@@ -37,7 +37,7 @@ type Msg
 
 
 type alias Pool =
-    Task.Pool Msg Error Output
+    Task.Pool Msg
 
 
 type alias Error =

--- a/examples/spa-example/src/Pages/Home_.elm
+++ b/examples/spa-example/src/Pages/Home_.elm
@@ -84,7 +84,7 @@ getTodo id =
 
 
 type alias Pool =
-    ConcurrentTask.Pool Msg Error Output
+    ConcurrentTask.Pool Msg
 
 
 type alias Error =

--- a/examples/spa-example/src/Pages/Posts.elm
+++ b/examples/spa-example/src/Pages/Posts.elm
@@ -89,7 +89,7 @@ getPost id =
 
 
 type alias Pool =
-    ConcurrentTask.Pool Msg Error Output
+    ConcurrentTask.Pool Msg
 
 
 type alias Error =

--- a/examples/spa-example/src/Spa/ConcurrentTask.elm
+++ b/examples/spa-example/src/Spa/ConcurrentTask.elm
@@ -6,8 +6,8 @@ import Json.Decode as Decode
 
 
 subscriptions :
-    (( ConcurrentTask.Pool msg x a, Cmd msg ) -> msg)
-    -> { model | tasks : ConcurrentTask.Pool msg x a }
+    (( ConcurrentTask.Pool msg, Cmd msg ) -> msg)
+    -> { model | tasks : ConcurrentTask.Pool msg }
     -> Sub msg
 subscriptions onProgress { tasks } =
     ConcurrentTask.onProgress
@@ -30,10 +30,10 @@ progress model ( tasks, cmd ) =
 
 attempt :
     { task : ConcurrentTask x a
-    , pool : ConcurrentTask.Pool msg x a
+    , pool : ConcurrentTask.Pool msg
     , onComplete : ConcurrentTask.Response x a -> msg
     }
-    -> ( ConcurrentTask.Pool msg x a, Cmd msg )
+    -> ( ConcurrentTask.Pool msg, Cmd msg )
 attempt { task, pool, onComplete } =
     ConcurrentTask.attempt
         { send = send

--- a/integration/src/Integration/Runner.elm
+++ b/integration/src/Integration/Runner.elm
@@ -35,7 +35,7 @@ type Msg
 
 
 type alias Pool =
-    Task.Pool Msg Error Output
+    Task.Pool Msg
 
 
 type alias Error =

--- a/src/ConcurrentTask.elm
+++ b/src/ConcurrentTask.elm
@@ -132,11 +132,11 @@ Here's a minimal complete example:
     import Json.Decode as Decode
 
     type alias Model =
-        { tasks : ConcurrentTask.Pool Msg Http.Error Titles
+        { tasks : ConcurrentTask.Pool Msg
         }
 
     type Msg
-        = OnProgress ( ConcurrentTask.Pool Msg Http.Error Titles, Cmd Msg )
+        = OnProgress ( ConcurrentTask.Pool Msg, Cmd Msg )
         | OnComplete (ConcurrentTask.Response Http.Error Titles)
 
     init : ( Model, Cmd Msg )

--- a/src/ConcurrentTask.elm
+++ b/src/ConcurrentTask.elm
@@ -882,18 +882,42 @@ Make sure to update your `Model` and pass in the `Cmd` returned from `attempt`. 
 
 -}
 attempt :
-    { pool : Pool msg x a
+    { pool : Pool msg
     , send : Decode.Value -> Cmd msg
     , onComplete : Response x a -> msg
     }
     -> ConcurrentTask x a
-    -> ( Pool msg x a, Cmd msg )
-attempt options =
+    -> ( Pool msg, Cmd msg )
+attempt config task =
+    let
+        mappedTask : ConcurrentTask msg msg
+        mappedTask =
+            task
+                |> map (\res -> config.onComplete (Success res))
+                |> onError
+                    (\err ->
+                        config.onComplete (Error err)
+                            |> succeed
+                    )
+
+        onComplete : Internal.Response msg msg -> msg
+        onComplete res =
+            case res of
+                Internal.Success s ->
+                    s
+
+                Internal.Error e ->
+                    e
+
+                Internal.UnexpectedError e ->
+                    config.onComplete (UnexpectedError (toUnexpectedError e))
+    in
     Internal.attempt
-        { pool = options.pool
-        , send = options.send
-        , onComplete = toResponse >> options.onComplete
+        { pool = config.pool
+        , send = config.send
+        , onComplete = onComplete
         }
+        mappedTask
 
 
 {-| The value returned from a task when it completes (returned in the `OnComplete` msg).
@@ -937,19 +961,6 @@ type UnexpectedError
     | ErrorsDecoderFailure { function : String, error : Decode.Error }
     | MissingFunction String
     | InternalError String
-
-
-toResponse : Internal.Response x a -> Response x a
-toResponse res =
-    case res of
-        Internal.Success a ->
-            Success a
-
-        Internal.Error x ->
-            Error x
-
-        Internal.UnexpectedError e ->
-            UnexpectedError (toUnexpectedError e)
 
 
 toUnexpectedError : Internal.UnexpectedError -> UnexpectedError
@@ -1000,9 +1011,9 @@ Make sure to update your `Model` and pass in the `Cmd` in your `OnProgress` bran
 onProgress :
     { send : Decode.Value -> Cmd msg
     , receive : (Decode.Value -> msg) -> Sub msg
-    , onProgress : ( Pool msg x a, Cmd msg ) -> msg
+    , onProgress : ( Pool msg, Cmd msg ) -> msg
     }
-    -> Pool msg x a
+    -> Pool msg
     -> Sub msg
 onProgress =
     Internal.onProgress
@@ -1011,8 +1022,8 @@ onProgress =
 {-| A Pool keeps track of each task's progress,
 and allows multiple Task attempts to be in-flight at the same time.
 -}
-type alias Pool msg x a =
-    Internal.Pool msg x a
+type alias Pool msg =
+    Internal.Pool msg
 
 
 {-| Create an empty ConcurrentTask Pool.
@@ -1024,6 +1035,6 @@ Right now it doesn't expose any functionality, but it could be used in the futur
   - Expose metrics on previous or running tasks.
 
 -}
-pool : Pool msg x a
+pool : Pool msg
 pool =
     Internal.pool


### PR DESCRIPTION
The current version of elm-concurrent-task requires the tasks to have uniform result/error types, as the types of `Task x a` are reflected in `Pool msg x a`.

This PR changes the API such that we can get away with a simpler `Pool msg`, which means that tasks can have any shape, and they just need to be converted to a uniform `Msg` when `attempt`ed. This makes it easier to use the library, especially in bigger projects