### PR TITLE
Add .js extensions to runner imports to produce valid esm

### DIFF
--- a/runner/index.ts
+++ b/runner/index.ts
@@ -1,16 +1,16 @@
-import { HttpRequest, HttpResponse } from "./http";
-import * as fetchAdapter from "./http/fetch";
+import { HttpRequest, HttpResponse } from "./http/index.js";
+import * as fetchAdapter from "./http/fetch.js";
 import {
   DomError,
   DomElement,
   Viewport,
   SetViewportOptions,
   SetViewportOfOptions,
-} from "./browser";
-import * as dom from "./browser/dom";
+} from "./browser/index.js";
+import * as dom from "./browser/dom.js";
 
-export * from "./http";
-export * from "./browser";
+export * from "./http/index.js";
+export * from "./browser/index.js";
 
 export interface ElmPorts {
   send: {


### PR DESCRIPTION
Closes #40

When using the concurrent task runner without transpiling in node, the generated esm JS was invalid, e.g.:

```js
import * as fetchAdapter from "./http/fetch";
```

needs to be

```js
import * as fetchAdapter from "./http/fetch.js";
```

This PR manually adds the `.js` extensions in, this could be done via a build tool but it feels like overkill given how stable the runner is right now.